### PR TITLE
#7: Insert HTML line breaks before all newlines in diff comments

### DIFF
--- a/lib/Differ/Comment.php
+++ b/lib/Differ/Comment.php
@@ -3,7 +3,6 @@
 namespace Differ;
 
 use \Model;
-use \Michelf\MarkdownExtra;
 
 class Comment extends Model
 {
@@ -12,6 +11,6 @@ class Comment extends Model
 
 	public function getCommentHtml()
 	{
-		return MarkdownExtra::defaultTransform($this->comment);
+		return DifferMarkdown::defaultTransform($this->comment);
 	}
 }

--- a/lib/Differ/Comment.php
+++ b/lib/Differ/Comment.php
@@ -11,6 +11,6 @@ class Comment extends Model
 
 	public function getCommentHtml()
 	{
-		return DifferMarkdown::defaultTransform($this->comment);
+		return Markdown::defaultTransform($this->comment);
 	}
 }

--- a/lib/Differ/DifferMarkdown.php
+++ b/lib/Differ/DifferMarkdown.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Differ;
+
+use \Michelf\MarkdownExtra;
+
+/**
+ * A Differ Flavored Markdown which differs from the derfault Markdown:
+ * 	<li> single new lines are treated as real line break </li>
+ *
+ * @package Differ
+ */
+class DifferMarkdown extends MarkdownExtra
+{
+	/**
+	 * Override the default doHardBreaks to treats newlines 
+	 * in paragraph-like content as real line breaks.
+	 *
+	 * @see \Michelf\Markdown::doHardBreaks()
+	 */
+	protected function doHardBreaks($text)
+	{
+		# Do hard breaks:
+		return preg_replace_callback('/ {2,}\n|\n{1}/', 
+			array(&$this, '_doHardBreaks_callback'), $text);
+	}
+}

--- a/lib/Differ/Markdown.php
+++ b/lib/Differ/Markdown.php
@@ -10,7 +10,7 @@ use \Michelf\MarkdownExtra;
  *
  * @package Differ
  */
-class DifferMarkdown extends MarkdownExtra
+class Markdown extends MarkdownExtra
 {
 	/**
 	 * Override the default doHardBreaks to treats newlines 


### PR DESCRIPTION
Added Differ Flavored Markdown class to implement the change. Method
doHardBreaks is overridden with the updated regex.
